### PR TITLE
Hotfix: Infinite Spinner on First Load

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -20,8 +20,9 @@ import tasksRoutes from './routes/tasks';
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-// Trust proxy - required for rate limiting behind NGINX
-app.set('trust proxy', true);
+// Trust proxy - trust first hop (NGINX) for rate limiting
+// Using numeric value 1 to trust only the immediate proxy (not blindly trust all)
+app.set('trust proxy', 1);
 
 // Middleware
 app.use(helmet());

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,6 +26,7 @@ http {
     # Rate limiting zones
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/m;
+    limit_req_zone $binary_remote_addr zone=auth_check:10m rate=30r/m;
 
     # Gzip compression
     gzip on;
@@ -57,6 +58,17 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_cache_bypass $http_upgrade;
+        }
+
+        # Session check endpoint (higher limit for polling)
+        location = /api/auth/me {
+            limit_req zone=auth_check burst=10 nodelay;
+            proxy_pass http://backend:3001;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         # Auth endpoints (stricter rate limiting)


### PR DESCRIPTION
## Critical Hotfix - Infinite Spinner Issue

Resolves infinite loading spinner on first page load caused by NGINX rate limiting.

### Issue

Frontend stuck in infinite spinner on initial load:
- Frontend polls `/api/auth/me` for session status
- NGINX rate limits ALL `/api/auth/*` to 5 requests/minute
- After 5 requests, NGINX returns 503
- Frontend enters retry loop → infinite spinner

### Root Causes

1. **NGINX rate limiting too aggressive**
   - All `/api/auth/*` endpoints limited to 5r/m
   - Session check endpoint needs higher limit for polling

2. **Backend trust proxy too permissive**
   - `trust proxy: true` allows IP spoofing
   - Security vulnerability + incorrect rate limiting

### Fixes Applied

#### 1. NGINX Rate Limiting (nginx/nginx.conf)

**Created separate rate limit zone for session checks:**
```nginx
limit_req_zone $binary_remote_addr zone=auth_check:10m rate=30r/m;
```

**Added specific location block for /api/auth/me (before /api/auth/):**
```nginx
location = /api/auth/me {
    limit_req zone=auth_check burst=10 nodelay;
    # ... proxy config
}
```

**Result:** 30 requests/minute for session checks, 5 requests/minute for login attempts

#### 2. Backend Trust Proxy (backend/src/server.ts)

**Changed from permissive to secure:**
```typescript
// Before: trust proxy: true (accepts any X-Forwarded-For)
// After:  trust proxy: 1    (trusts only immediate proxy)
app.set('trust proxy', 1);
```

**Result:** Only trusts NGINX proxy headers, prevents IP spoofing

### Testing

✅ 10 consecutive `/api/auth/me` requests succeed (401 unauthorized, not 503 rate limited)
✅ No ValidationError in backend logs
✅ Backend health check operational
✅ All services running correctly

### Impact

- Frontend loads without infinite spinner
- Session polling works correctly
- Rate limiting functions properly
- Security vulnerability resolved

### Deployment

Ready for immediate merge - critical user-facing bug resolved.