### PR TITLE
Add Sessions, Metrics, and ProjectDetail pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,9 @@ import { Layout } from 'antd';
 import DashboardPage from './pages/DashboardPage';
 import RunnersPage from './pages/RunnersPage';
 import ProjectsPage from './pages/ProjectsPage';
+import SessionsPage from './pages/SessionsPage';
+import MetricsPage from './pages/MetricsPage';
+import ProjectDetailPage from './pages/ProjectDetailPage';
 
 const { Content } = Layout;
 
@@ -16,6 +19,9 @@ function App(): React.ReactElement {
             <Route path="/" element={<DashboardPage />} />
             <Route path="/runners" element={<RunnersPage />} />
             <Route path="/projects" element={<ProjectsPage />} />
+            <Route path="/projects/:name" element={<ProjectDetailPage />} />
+            <Route path="/sessions" element={<SessionsPage />} />
+            <Route path="/metrics" element={<MetricsPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </Content>

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -13,6 +13,8 @@ export const AppHeader: React.FC = () => {
     { path: '/', label: 'Dashboard' },
     { path: '/runners', label: 'Runners' },
     { path: '/projects', label: 'Projects' },
+    { path: '/sessions', label: 'Sessions' },
+    { path: '/metrics', label: 'Metrics' },
   ];
 
   return (

--- a/frontend/src/pages/MetricsPage.tsx
+++ b/frontend/src/pages/MetricsPage.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Layout, Card, Row, Col, Typography, Alert, Skeleton, Button, Space, Tooltip,
+  Statistic,
+} from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import { metricsApi } from '../services/stratavore.service';
+import { AppHeader } from '../components/AppHeader';
+import type { GlobalMetrics } from '../types/stratavore';
+
+const { Content } = Layout;
+const { Title } = Typography;
+
+const REFRESH_INTERVAL_MS = 10000;
+
+export default function MetricsPage(): React.ReactElement {
+  const [metrics, setMetrics] = useState<GlobalMetrics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date>(new Date());
+
+  const fetchMetrics = useCallback(async () => {
+    try {
+      const data = await metricsApi.getMetrics();
+      setMetrics(data);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch {
+      setError('Failed to load fleet metrics from Stratavore daemon.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMetrics();
+    const interval = setInterval(fetchMetrics, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchMetrics]);
+
+  return (
+    <Layout>
+      <AppHeader />
+      <Content style={{ padding: 24, minHeight: 'calc(100vh - 64px)' }}>
+        {error && (
+          <Alert
+            message="Metrics Unavailable"
+            description={error}
+            type="error"
+            closable
+            onClose={() => setError(null)}
+            style={{ marginBottom: 16 }}
+          />
+        )}
+
+        <Row gutter={[16, 16]} align="middle" style={{ marginBottom: 16 }}>
+          <Col>
+            <Title level={4} style={{ margin: 0 }}>Fleet Metrics</Title>
+          </Col>
+          <Col flex="auto" />
+          <Col>
+            <Space>
+              <Tooltip title={`Last updated: ${lastUpdated.toLocaleTimeString()}`}>
+                <Button icon={<ReloadOutlined />} onClick={fetchMetrics} size="small" />
+              </Tooltip>
+            </Space>
+          </Col>
+        </Row>
+
+        <Row gutter={[16, 16]}>
+          <Col xs={12} sm={8} md={6} lg={4}>
+            <Card>
+              {loading && !metrics ? (
+                <Skeleton active paragraph={false} />
+              ) : (
+                <Statistic
+                  title="Active Runners"
+                  value={metrics?.activeRunners ?? 0}
+                />
+              )}
+            </Card>
+          </Col>
+          <Col xs={12} sm={8} md={6} lg={4}>
+            <Card>
+              {loading && !metrics ? (
+                <Skeleton active paragraph={false} />
+              ) : (
+                <Statistic
+                  title="Active Projects"
+                  value={metrics?.activeProjects ?? 0}
+                />
+              )}
+            </Card>
+          </Col>
+          <Col xs={12} sm={8} md={6} lg={4}>
+            <Card>
+              {loading && !metrics ? (
+                <Skeleton active paragraph={false} />
+              ) : (
+                <Statistic
+                  title="Total Sessions"
+                  value={metrics?.totalSessions ?? 0}
+                />
+              )}
+            </Card>
+          </Col>
+          <Col xs={12} sm={8} md={6} lg={6}>
+            <Card>
+              {loading && !metrics ? (
+                <Skeleton active paragraph={false} />
+              ) : (
+                <Statistic
+                  title="Tokens Used"
+                  value={metrics?.tokensUsed ?? 0}
+                  formatter={(v) => Number(v).toLocaleString()}
+                />
+              )}
+            </Card>
+          </Col>
+          <Col xs={12} sm={8} md={6} lg={6}>
+            <Card>
+              {loading && !metrics ? (
+                <Skeleton active paragraph={false} />
+              ) : (
+                <Statistic
+                  title="Token Limit"
+                  value={
+                    metrics?.tokenLimit === 0 || metrics?.tokenLimit == null
+                      ? 'Unlimited'
+                      : metrics.tokenLimit
+                  }
+                  formatter={(v) =>
+                    v === 'Unlimited' ? 'Unlimited' : Number(v).toLocaleString()
+                  }
+                />
+              )}
+            </Card>
+          </Col>
+        </Row>
+      </Content>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,0 +1,233 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Layout, Typography, Alert, Descriptions, Tag, Button, Space,
+  Skeleton, Popconfirm, Table,
+} from 'antd';
+import { DeleteOutlined, ArrowLeftOutlined, ReloadOutlined } from '@ant-design/icons';
+import { useParams, useNavigate } from 'react-router-dom';
+import type { ColumnsType } from 'antd/es/table';
+import { projectApi, sessionApi } from '../services/stratavore.service';
+import { AppHeader } from '../components/AppHeader';
+import type { Project, Session } from '../types/stratavore';
+
+const { Content } = Layout;
+const { Title } = Typography;
+
+export default function ProjectDetailPage(): React.ReactElement {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+
+  const [project, setProject] = useState<Project | null>(null);
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loadingProject, setLoadingProject] = useState(true);
+  const [loadingSessions, setLoadingSessions] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchProject = useCallback(async () => {
+    if (!name) return;
+    setLoadingProject(true);
+    try {
+      const data = await projectApi.getProject(name);
+      setProject(data);
+      setError(null);
+    } catch {
+      setError(`Failed to load project "${name}".`);
+    } finally {
+      setLoadingProject(false);
+    }
+  }, [name]);
+
+  const fetchSessions = useCallback(async () => {
+    if (!name) return;
+    setLoadingSessions(true);
+    try {
+      const data = await sessionApi.listSessions(name);
+      setSessions(data);
+    } catch {
+      // Sessions may not exist yet — soft failure
+      setSessions([]);
+    } finally {
+      setLoadingSessions(false);
+    }
+  }, [name]);
+
+  useEffect(() => {
+    fetchProject();
+    fetchSessions();
+  }, [fetchProject, fetchSessions]);
+
+  async function handleDelete() {
+    if (!name) return;
+    setDeleting(true);
+    try {
+      await projectApi.deleteProject(name);
+      navigate('/projects');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to delete project.';
+      setError(message);
+      setDeleting(false);
+    }
+  }
+
+  const sessionColumns: ColumnsType<Session> = [
+    {
+      title: 'Session ID',
+      dataIndex: 'id',
+      render: (id: string) => (
+        <span title={id} style={{ fontFamily: 'monospace', fontSize: 13 }}>
+          {id.slice(0, 8)}
+        </span>
+      ),
+    },
+    {
+      title: 'Started At',
+      dataIndex: 'started_at',
+      render: (ts: string) => ts ? new Date(ts).toLocaleString() : '—',
+      sorter: (a, b) =>
+        new Date(a.started_at || 0).getTime() - new Date(b.started_at || 0).getTime(),
+    },
+    {
+      title: 'Ended At',
+      dataIndex: 'ended_at',
+      render: (ts?: string) =>
+        ts ? new Date(ts).toLocaleString() : <Tag color="processing">Active</Tag>,
+    },
+    {
+      title: 'Messages',
+      dataIndex: 'message_count',
+      sorter: (a, b) => a.message_count - b.message_count,
+    },
+    {
+      title: 'Tokens Used',
+      dataIndex: 'tokens_used',
+      render: (n: number) => n?.toLocaleString() ?? '0',
+      sorter: (a, b) => a.tokens_used - b.tokens_used,
+    },
+    {
+      title: 'Resumable',
+      dataIndex: 'resumable',
+      render: (v: boolean) => (
+        <Tag color={v ? 'success' : 'default'}>{v ? 'YES' : 'NO'}</Tag>
+      ),
+    },
+    {
+      title: 'Summary',
+      dataIndex: 'summary',
+      ellipsis: true,
+      render: (text?: string) => text ?? '—',
+    },
+  ];
+
+  return (
+    <Layout>
+      <AppHeader />
+      <Content style={{ padding: 24, minHeight: 'calc(100vh - 64px)' }}>
+        {error && (
+          <Alert
+            message={error}
+            type="error"
+            closable
+            onClose={() => setError(null)}
+            style={{ marginBottom: 16 }}
+          />
+        )}
+
+        <Space style={{ marginBottom: 16 }} align="center">
+          <Button
+            icon={<ArrowLeftOutlined />}
+            onClick={() => navigate('/projects')}
+            size="small"
+          >
+            Projects
+          </Button>
+          <Title level={4} style={{ margin: 0 }}>
+            {name ?? ''}
+          </Title>
+          <Button icon={<ReloadOutlined />} onClick={() => { fetchProject(); fetchSessions(); }} size="small" />
+          <Popconfirm
+            title="Delete project"
+            description={`Permanently delete "${name}"? This cannot be undone.`}
+            onConfirm={handleDelete}
+            okText="Delete"
+            okType="danger"
+            cancelText="Cancel"
+          >
+            <Button
+              icon={<DeleteOutlined />}
+              danger
+              loading={deleting}
+              size="small"
+            >
+              Delete
+            </Button>
+          </Popconfirm>
+        </Space>
+
+        {loadingProject ? (
+          <Skeleton active />
+        ) : project ? (
+          <Descriptions
+            bordered
+            size="small"
+            column={{ xs: 1, sm: 2, md: 2 }}
+            style={{ marginBottom: 24 }}
+          >
+            <Descriptions.Item label="Name">{project.name}</Descriptions.Item>
+            <Descriptions.Item label="Status">
+              <Tag
+                color={
+                  project.status === 'active'
+                    ? 'success'
+                    : project.status === 'archived'
+                    ? 'default'
+                    : 'processing'
+                }
+              >
+                {project.status?.toUpperCase() ?? 'UNKNOWN'}
+              </Tag>
+            </Descriptions.Item>
+            <Descriptions.Item label="Path" span={2}>
+              <span style={{ fontFamily: 'monospace' }}>{project.path}</span>
+            </Descriptions.Item>
+            <Descriptions.Item label="Description" span={2}>
+              {project.description || '—'}
+            </Descriptions.Item>
+            <Descriptions.Item label="Tags">
+              {project.tags?.length
+                ? project.tags.map((t) => <Tag key={t}>{t}</Tag>)
+                : '—'}
+            </Descriptions.Item>
+            <Descriptions.Item label="Active Runners">
+              {project.activeRunners} / {project.totalRunners}
+            </Descriptions.Item>
+            <Descriptions.Item label="Total Sessions">
+              {project.totalSessions}
+            </Descriptions.Item>
+            <Descriptions.Item label="Total Tokens">
+              {project.totalTokens?.toLocaleString() ?? '0'}
+            </Descriptions.Item>
+            <Descriptions.Item label="Created At">
+              {project.createdAt ? new Date(project.createdAt).toLocaleString() : '—'}
+            </Descriptions.Item>
+            <Descriptions.Item label="Last Accessed">
+              {project.lastAccessedAt
+                ? new Date(project.lastAccessedAt).toLocaleString()
+                : '—'}
+            </Descriptions.Item>
+          </Descriptions>
+        ) : null}
+
+        <Title level={5} style={{ marginBottom: 12 }}>Sessions</Title>
+        <Table<Session>
+          dataSource={sessions}
+          columns={sessionColumns}
+          rowKey="id"
+          loading={loadingSessions}
+          pagination={{ pageSize: 20 }}
+          size="small"
+        />
+      </Content>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -4,6 +4,7 @@ import {
   Modal, Form, Input, Alert, Tag,
 } from 'antd';
 import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
+import { Link } from 'react-router-dom';
 import type { ColumnsType } from 'antd/es/table';
 import { projectApi } from '../services/stratavore.service';
 import { AppHeader } from '../components/AppHeader';
@@ -55,7 +56,11 @@ export default function ProjectsPage(): React.ReactElement {
       title: 'Name',
       dataIndex: 'name',
       sorter: (a, b) => a.name.localeCompare(b.name),
-      render: (name: string) => <strong>{name}</strong>,
+      render: (name: string) => (
+        <Link to={`/projects/${encodeURIComponent(name)}`}>
+          <strong>{name}</strong>
+        </Link>
+      ),
     },
     {
       title: 'Status',

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -1,0 +1,177 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Layout, Table, Typography, Alert, Tag, Select, Space, Button, Empty,
+} from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import { useSearchParams } from 'react-router-dom';
+import type { ColumnsType } from 'antd/es/table';
+import { sessionApi, projectApi } from '../services/stratavore.service';
+import { AppHeader } from '../components/AppHeader';
+import type { Session, Project } from '../types/stratavore';
+
+const { Content } = Layout;
+const { Title } = Typography;
+
+export default function SessionsPage(): React.ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const projectParam = searchParams.get('project') ?? '';
+
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loadingSessions, setLoadingSessions] = useState(false);
+  const [loadingProjects, setLoadingProjects] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProjects = useCallback(async () => {
+    try {
+      const data = await projectApi.listProjects();
+      setProjects(data);
+    } catch {
+      setError('Failed to load project list.');
+    } finally {
+      setLoadingProjects(false);
+    }
+  }, []);
+
+  const fetchSessions = useCallback(async (project: string) => {
+    if (!project) return;
+    setLoadingSessions(true);
+    try {
+      const data = await sessionApi.listSessions(project);
+      setSessions(data);
+      setError(null);
+    } catch {
+      setError(`Failed to load sessions for project "${project}".`);
+    } finally {
+      setLoadingSessions(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
+
+  useEffect(() => {
+    if (projectParam) {
+      fetchSessions(projectParam);
+    } else {
+      setSessions([]);
+    }
+  }, [projectParam, fetchSessions]);
+
+  function handleProjectChange(value: string) {
+    setSearchParams(value ? { project: value } : {});
+  }
+
+  const columns: ColumnsType<Session> = [
+    {
+      title: 'Session ID',
+      dataIndex: 'id',
+      render: (id: string) => (
+        <span title={id} style={{ fontFamily: 'monospace', fontSize: 13 }}>
+          {id.slice(0, 8)}
+        </span>
+      ),
+    },
+    {
+      title: 'Project',
+      dataIndex: 'project_name',
+    },
+    {
+      title: 'Started At',
+      dataIndex: 'started_at',
+      render: (ts: string) => ts ? new Date(ts).toLocaleString() : '—',
+      sorter: (a, b) =>
+        new Date(a.started_at || 0).getTime() - new Date(b.started_at || 0).getTime(),
+    },
+    {
+      title: 'Ended At',
+      dataIndex: 'ended_at',
+      render: (ts?: string) =>
+        ts ? new Date(ts).toLocaleString() : <Tag color="processing">Active</Tag>,
+    },
+    {
+      title: 'Messages',
+      dataIndex: 'message_count',
+      sorter: (a, b) => a.message_count - b.message_count,
+    },
+    {
+      title: 'Tokens Used',
+      dataIndex: 'tokens_used',
+      render: (n: number) => n?.toLocaleString() ?? '0',
+      sorter: (a, b) => a.tokens_used - b.tokens_used,
+    },
+    {
+      title: 'Resumable',
+      dataIndex: 'resumable',
+      render: (v: boolean) => (
+        <Tag color={v ? 'success' : 'default'}>{v ? 'YES' : 'NO'}</Tag>
+      ),
+    },
+    {
+      title: 'Summary',
+      dataIndex: 'summary',
+      ellipsis: true,
+      render: (text?: string) => text ?? '—',
+    },
+  ];
+
+  return (
+    <Layout>
+      <AppHeader />
+      <Content style={{ padding: 24, minHeight: 'calc(100vh - 64px)' }}>
+        {error && (
+          <Alert
+            message={error}
+            type="error"
+            closable
+            onClose={() => setError(null)}
+            style={{ marginBottom: 16 }}
+          />
+        )}
+
+        <Space style={{ marginBottom: 16 }} align="center">
+          <Title level={4} style={{ margin: 0 }}>Sessions</Title>
+          <Select
+            showSearch
+            placeholder="Select a project"
+            style={{ width: 260 }}
+            loading={loadingProjects}
+            value={projectParam || undefined}
+            onChange={handleProjectChange}
+            allowClear
+            filterOption={(input, option) =>
+              String(option?.value ?? '').toLowerCase().includes(input.toLowerCase())
+            }
+          >
+            {projects.map((p) => (
+              <Select.Option key={p.name} value={p.name}>
+                {p.name}
+              </Select.Option>
+            ))}
+          </Select>
+          {projectParam && (
+            <Button
+              icon={<ReloadOutlined />}
+              onClick={() => fetchSessions(projectParam)}
+              disabled={loadingSessions}
+            />
+          )}
+        </Space>
+
+        {!projectParam ? (
+          <Empty description="Select a project to view its sessions." />
+        ) : (
+          <Table<Session>
+            dataSource={sessions}
+            columns={columns}
+            rowKey="id"
+            loading={loadingSessions}
+            pagination={{ pageSize: 25 }}
+            size="small"
+          />
+        )}
+      </Content>
+    </Layout>
+  );
+}

--- a/frontend/src/services/stratavore.service.ts
+++ b/frontend/src/services/stratavore.service.ts
@@ -2,6 +2,8 @@ import { stratavoreApi } from './api';
 import type {
   Runner,
   Project,
+  Session,
+  GlobalMetrics,
   StatusResponse,
   LaunchRunnerRequest,
   StopRunnerRequest,
@@ -75,5 +77,60 @@ export const projectApi = {
     const r = await stratavoreApi.post<{ project: Project; error?: string }>('/projects/create', req);
     if (r.data.error) throw new Error(r.data.error);
     return r.data.project;
+  },
+
+  async getProject(name: string): Promise<Project> {
+    const r = await stratavoreApi.get<{ project: Project; error?: string }>(
+      `/projects/get?name=${encodeURIComponent(name)}`
+    );
+    if (r.data.error) throw new Error(r.data.error);
+    return r.data.project;
+  },
+
+  async deleteProject(name: string): Promise<void> {
+    const r = await stratavoreApi.post<{ success: boolean; error?: string }>('/projects/delete', { name });
+    if (!r.data.success && r.data.error) throw new Error(r.data.error);
+  },
+};
+
+// Sessions
+
+export const sessionApi = {
+  async listSessions(project: string): Promise<Session[]> {
+    const r = await stratavoreApi.get<{ sessions: Session[]; error?: string }>(
+      `/sessions/list?project=${encodeURIComponent(project)}`
+    );
+    if (r.data.error) throw new Error(r.data.error);
+    return r.data.sessions ?? [];
+  },
+
+  async getSession(sessionId: string): Promise<Session> {
+    const r = await stratavoreApi.get<{ session: Session; error?: string }>(
+      `/sessions/get?session_id=${encodeURIComponent(sessionId)}`
+    );
+    if (r.data.error) throw new Error(r.data.error);
+    return r.data.session;
+  },
+};
+
+// Metrics
+
+export const metricsApi = {
+  async getMetrics(): Promise<GlobalMetrics> {
+    const r = await stratavoreApi.get<{
+      active_runners: number;
+      active_projects: number;
+      total_sessions: number;
+      tokens_used: number;
+      token_limit: number;
+    }>('/metrics');
+    const d = r.data;
+    return {
+      activeRunners: d.active_runners,
+      activeProjects: d.active_projects,
+      totalSessions: d.total_sessions,
+      tokensUsed: d.tokens_used,
+      tokenLimit: d.token_limit,
+    };
   },
 };

--- a/frontend/src/types/stratavore.ts
+++ b/frontend/src/types/stratavore.ts
@@ -98,3 +98,18 @@ export interface ReconcileResponse {
   failedRunnerIds: string[];
   error?: string;
 }
+
+export interface Session {
+  id: string;
+  runner_id: string;
+  project_name: string;
+  started_at: string;
+  ended_at?: string;
+  last_message_at?: string;
+  message_count: number;
+  tokens_used: number;
+  resumable: boolean;
+  resumed_from?: string;
+  summary?: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary

- New `SessionsPage` — project-scoped session list with status, token usage, resumability
- New `MetricsPage` — fleet-wide stats (active runners, projects, sessions, token usage) with 10s auto-refresh
- New `ProjectDetailPage` — full project metadata + embedded session table + delete action
- `ProjectsPage` — project names now link through to the detail page
- `App.tsx` + `AppHeader.tsx` — new routes and nav items wired up

## Replaces

PR #10 — identical content, fresh branch to resolve GitHub merge state false-positive (branch ancestry issue from squash-merge of #8).

## Test plan

- [ ] Type-check: `npm run type-check` — passes
- [ ] Tests: `npm test -- --run` — 8/8 passing
- [ ] CI verify workflow passes on push