### PR TITLE
Rename project to stratavore-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Comprehensive web interface for the Meridian Lex autonomous development system.
 
 ## v3 — Stratavore Integration
 
-Lex-webui v3 connects directly to the [Stratavore](https://github.com/Meridian-Lex/Stratavore) control plane HTTP API. The Node.js v1 backend has been removed.
+stratavore-ui v3 connects directly to the [Stratavore](https://github.com/Meridian-Lex/Stratavore) control plane HTTP API. The Node.js v1 backend has been removed.
 
 ### Quick start (development)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lex-webui-frontend",
+  "name": "stratavore-ui",
   "version": "1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- `package.json` name: `lex-webui-frontend` → `stratavore-ui`
- `README.md`: all `Lex-webui` / `lex-webui` references updated to `stratavore-ui`
- GitHub repo already renamed from `Lex-webui` to `stratavore-ui`

No functional changes.