### PR TITLE
feat: Fleet PRs page — open PR dashboard across all fleet repos

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import ProjectsPage from './pages/ProjectsPage';
 import SessionsPage from './pages/SessionsPage';
 import MetricsPage from './pages/MetricsPage';
 import ProjectDetailPage from './pages/ProjectDetailPage';
+import FleetPRsPage from './pages/FleetPRsPage';
 
 const { Content } = Layout;
 
@@ -22,6 +23,7 @@ function App(): React.ReactElement {
             <Route path="/projects/:name" element={<ProjectDetailPage />} />
             <Route path="/sessions" element={<SessionsPage />} />
             <Route path="/metrics" element={<MetricsPage />} />
+            <Route path="/fleet-prs" element={<FleetPRsPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </Content>

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -15,6 +15,7 @@ export const AppHeader: React.FC = () => {
     { path: '/projects', label: 'Projects' },
     { path: '/sessions', label: 'Sessions' },
     { path: '/metrics', label: 'Metrics' },
+    { path: '/fleet-prs', label: 'Fleet PRs' },
   ];
 
   return (

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -37,14 +37,16 @@ export const AppHeader: React.FC = () => {
             item.path === '/'
               ? location.pathname === '/'
               : location.pathname.startsWith(item.path);
-          if (isActive) {
-            return null;
-          }
           return (
             <Link
               key={item.path}
               to={item.path}
-              style={{ color: 'white', marginRight: 24 }}
+              style={{
+                color: 'white',
+                marginRight: 24,
+                fontWeight: isActive ? 'bold' : 'normal',
+                textDecoration: isActive ? 'underline' : 'none',
+              }}
             >
               {item.label}
             </Link>

--- a/frontend/src/pages/FleetPRsPage.tsx
+++ b/frontend/src/pages/FleetPRsPage.tsx
@@ -54,10 +54,10 @@ export default function FleetPRsPage(): React.ReactElement {
     return () => clearInterval(interval);
   }, [fetchPRs]);
 
-  async function handleRefresh() {
+  const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     await fetchPRs(true);
-  }
+  }, [fetchPRs]);
 
   const columns: ColumnsType<FleetPR> = [
     {

--- a/frontend/src/pages/FleetPRsPage.tsx
+++ b/frontend/src/pages/FleetPRsPage.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Layout, Table, Tag, Button, Space, Typography, Alert, Tooltip,
+} from 'antd';
+import { ReloadOutlined, WarningOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { fleetApi } from '../services/fleetService';
+import { AppHeader } from '../components/AppHeader';
+import type { FleetPR } from '../types/fleet';
+
+const { Content } = Layout;
+const { Title, Text } = Typography;
+
+// Repos that are expected to have @LunarLaurus assigned on every PR
+const REQUIRED_ASSIGNEE = 'LunarLaurus';
+
+// Auto-refresh interval matching backend cache TTL
+const REFRESH_INTERVAL_MS = 120_000;
+
+function formatAge(dateStr: string): string {
+  const ms = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(ms / 60_000);
+  const hours = Math.floor(ms / 3_600_000);
+  const days = Math.floor(ms / 86_400_000);
+  if (days > 0) return `${days}d`;
+  if (hours > 0) return `${hours}h`;
+  return `${minutes}m`;
+}
+
+export default function FleetPRsPage(): React.ReactElement {
+  const [prs, setPRs] = useState<FleetPR[]>([]);
+  const [cachedAt, setCachedAt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPRs = useCallback(async (forceRefresh = false) => {
+    try {
+      const data = await fleetApi.listOpenPRs(forceRefresh);
+      setPRs(data.prs ?? []);
+      setCachedAt(data.cached_at);
+      setError(null);
+    } catch {
+      setError('Failed to load fleet PRs from Stratavore. Is the daemon running?');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPRs();
+    const interval = setInterval(() => fetchPRs(), REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchPRs]);
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    await fetchPRs(true);
+  }
+
+  const columns: ColumnsType<FleetPR> = [
+    {
+      title: 'Repo',
+      dataIndex: 'repo',
+      render: (repo: string, record: FleetPR) => {
+        const hasRequired = record.assignees.includes(REQUIRED_ASSIGNEE);
+        return (
+          <Space size={4}>
+            <Text code style={{ fontSize: 12 }}>{repo.replace('Meridian-Lex/', '')}</Text>
+            {!hasRequired && (
+              <Tooltip title={`@${REQUIRED_ASSIGNEE} not assigned`}>
+                <Tag icon={<WarningOutlined />} color="warning" style={{ margin: 0 }}>
+                  unassigned
+                </Tag>
+              </Tooltip>
+            )}
+          </Space>
+        );
+      },
+      sorter: (a, b) => a.repo.localeCompare(b.repo),
+    },
+    {
+      title: '#',
+      dataIndex: 'number',
+      width: 70,
+      render: (num: number, record: FleetPR) => (
+        <a href={record.url} target="_blank" rel="noopener noreferrer">
+          #{num}
+        </a>
+      ),
+    },
+    {
+      title: 'Title',
+      dataIndex: 'title',
+      render: (title: string, record: FleetPR) => (
+        <Space size={4}>
+          {record.draft && <Tag color="default">draft</Tag>}
+          <a href={record.url} target="_blank" rel="noopener noreferrer">
+            {title}
+          </a>
+        </Space>
+      ),
+    },
+    {
+      title: 'Author',
+      dataIndex: 'author',
+      width: 130,
+    },
+    {
+      title: 'Age',
+      dataIndex: 'created_at',
+      width: 80,
+      render: (d: string) => formatAge(d),
+      sorter: (a, b) =>
+        new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    },
+  ];
+
+  return (
+    <Layout>
+      <AppHeader />
+      <Content style={{ padding: 24, minHeight: 'calc(100vh - 64px)' }}>
+        {error && (
+          <Alert
+            message={error}
+            type="error"
+            closable
+            onClose={() => setError(null)}
+            style={{ marginBottom: 16 }}
+          />
+        )}
+
+        <Space style={{ marginBottom: 16 }} align="center">
+          <Title level={4} style={{ margin: 0 }}>Fleet PRs</Title>
+          <Button
+            icon={<ReloadOutlined />}
+            onClick={handleRefresh}
+            loading={refreshing}
+          >
+            Refresh
+          </Button>
+        </Space>
+
+        <Table<FleetPR>
+          dataSource={prs}
+          columns={columns}
+          rowKey={(r) => `${r.repo}#${r.number}`}
+          loading={loading}
+          pagination={false}
+          size="small"
+          locale={{ emptyText: 'No open PRs across fleet.' }}
+          rowClassName={(r) => (r.draft ? 'draft-row' : '')}
+        />
+
+        {cachedAt && (
+          <Text type="secondary" style={{ marginTop: 8, display: 'block', fontSize: 12 }}>
+            Last updated: {new Date(cachedAt).toLocaleString()} — auto-refreshes every 2 minutes
+          </Text>
+        )}
+      </Content>
+    </Layout>
+  );
+}

--- a/frontend/src/services/fleetService.ts
+++ b/frontend/src/services/fleetService.ts
@@ -1,0 +1,11 @@
+import { stratavoreApi } from './api';
+import type { FleetPRsResponse } from '../types/fleet';
+
+export const fleetApi = {
+  async listOpenPRs(refresh = false): Promise<FleetPRsResponse> {
+    const params: Record<string, string> = {};
+    if (refresh) params.refresh = 'true';
+    const r = await stratavoreApi.get<FleetPRsResponse>('/fleet/prs', { params });
+    return r.data;
+  },
+};

--- a/frontend/src/types/fleet.ts
+++ b/frontend/src/types/fleet.ts
@@ -1,0 +1,18 @@
+// Fleet PR types — matches GET /api/v1/fleet/prs response shape
+
+export interface FleetPR {
+  repo: string;
+  number: number;
+  title: string;
+  author: string;
+  created_at: string;
+  draft: boolean;
+  assignees: string[];
+  url: string;
+}
+
+export interface FleetPRsResponse {
+  prs: FleetPR[];
+  cached_at: string;
+  total: number;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,6 @@
 // v3: Stratavore types — source of truth for all operational data
 export * from './stratavore';
+export type { FleetPR, FleetPRsResponse } from './fleet';
 
 // Legacy User type kept for auth context (simplified in v3)
 export interface User {


### PR DESCRIPTION
## Summary
- New /fleet-prs page displaying open PRs across all fleet repositories
- Consumes GET /api/v1/fleet/prs from Stratavore (Task 44 endpoint)
- Auto-refreshes every 2 minutes matching backend cache TTL
- PRs without @LunarLaurus assigned show warning tag
- Draft PRs visually distinguished with draft tag
- Manual refresh button with loading state
- Last updated timestamp displayed below table

## Test plan
- [ ] npm run type-check passes
- [ ] npm run build succeeds
- [ ] /fleet-prs route loads and shows Fleet PRs page
- [ ] Fleet PRs link appears in header nav
- [ ] Table displays PRs when Stratavore daemon is running with valid GitHub token
- [ ] PRs missing @LunarLaurus show warning tag in Repo column
- [ ] Draft PRs show draft tag in Title column
- [ ] Refresh button triggers cache bypass (GET /fleet/prs?refresh=true)
- [ ] Error alert shown when API unreachable